### PR TITLE
clean/improve-naming

### DIFF
--- a/app/src/main/java/nl/jaysh/recipe/core/data/network/model/search/SearchResultDTO.kt
+++ b/app/src/main/java/nl/jaysh/recipe/core/data/network/model/search/SearchResultDTO.kt
@@ -1,7 +1,7 @@
 package nl.jaysh.recipe.core.data.network.model.search
 
 import kotlinx.serialization.Serializable
-import nl.jaysh.recipe.core.domain.model.search.SearchRecipeResult
+import nl.jaysh.recipe.core.domain.model.search.SearchResult
 
 @Serializable
 data class SearchResultDTO(
@@ -12,7 +12,7 @@ data class SearchResultDTO(
     val readyInMinutes: Int,
 )
 
-fun SearchResultDTO.toSearchResult(): SearchRecipeResult = SearchRecipeResult(
+fun SearchResultDTO.toSearchResult(): SearchResult = SearchResult(
     id = id,
     title = title,
     summary = summary,

--- a/app/src/main/java/nl/jaysh/recipe/core/data/network/service/RecipeRemoteDataSource.kt
+++ b/app/src/main/java/nl/jaysh/recipe/core/data/network/service/RecipeRemoteDataSource.kt
@@ -5,7 +5,7 @@ import nl.jaysh.recipe.core.data.network.model.detail.RecipeDetailDTO
 import nl.jaysh.recipe.core.data.network.model.search.SearchResponseDTO
 import nl.jaysh.recipe.core.domain.model.failure.Failure
 
-interface RecipeService {
-    suspend fun searchRecipes(query: String): Either<Failure, SearchResponseDTO>
-    suspend fun fetchRecipeDetail(recipeId: Long): Either<Failure, RecipeDetailDTO>
+interface RecipeRemoteDataSource {
+    suspend fun search(query: String): Either<Failure, SearchResponseDTO>
+    suspend fun getDetails(recipeId: Long): Either<Failure, RecipeDetailDTO>
 }

--- a/app/src/main/java/nl/jaysh/recipe/core/data/network/service/RecipeRemoteDataSourceImpl.kt
+++ b/app/src/main/java/nl/jaysh/recipe/core/data/network/service/RecipeRemoteDataSourceImpl.kt
@@ -22,9 +22,11 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class RecipeServiceImpl @Inject constructor(private val httpClient: HttpClient) : RecipeService {
+class RecipeRemoteDataSourceImpl @Inject constructor(
+    private val httpClient: HttpClient,
+) : RecipeRemoteDataSource {
 
-    override suspend fun searchRecipes(query: String): Either<Failure, SearchResponseDTO> {
+    override suspend fun search(query: String): Either<Failure, SearchResponseDTO> {
         val path = "/recipes/complexSearch"
 
         return Either.catch {
@@ -37,7 +39,7 @@ class RecipeServiceImpl @Inject constructor(private val httpClient: HttpClient) 
         }.mapLeft(::mapToFailure)
     }
 
-    override suspend fun fetchRecipeDetail(recipeId: Long): Either<Failure, RecipeDetailDTO> {
+    override suspend fun getDetails(recipeId: Long): Either<Failure, RecipeDetailDTO> {
         val path = "/recipes/$recipeId/information"
 
         return Either.catch {

--- a/app/src/main/java/nl/jaysh/recipe/core/domain/RecipeRepository.kt
+++ b/app/src/main/java/nl/jaysh/recipe/core/domain/RecipeRepository.kt
@@ -4,11 +4,11 @@ import arrow.core.Either
 import kotlinx.coroutines.flow.Flow
 import nl.jaysh.recipe.core.domain.model.detail.RecipeDetail
 import nl.jaysh.recipe.core.domain.model.failure.Failure
-import nl.jaysh.recipe.core.domain.model.search.SearchRecipeResult
+import nl.jaysh.recipe.core.domain.model.search.SearchResult
 
 interface RecipeRepository {
-    fun searchRecipes(query: String): Flow<Either<Failure, List<SearchRecipeResult>>>
-    fun fetchRecipeDetail(recipeId: Long): Flow<Either<Failure, RecipeDetail>?>
+    fun search(query: String): Flow<Either<Failure, List<SearchResult>>>
+    fun getDetails(recipeId: Long): Flow<Either<Failure, RecipeDetail>?>
     suspend fun setFavouriteRecipe(recipeId: Long, isFavourite: Boolean)
     fun getFavouriteRecipe(): Flow<Either<Failure, List<RecipeDetail>>>
 }

--- a/app/src/main/java/nl/jaysh/recipe/core/domain/model/search/SearchResult.kt
+++ b/app/src/main/java/nl/jaysh/recipe/core/domain/model/search/SearchResult.kt
@@ -1,6 +1,6 @@
 package nl.jaysh.recipe.core.domain.model.search
 
-data class SearchRecipeResult(
+data class SearchResult(
     val id: Long,
     val title: String,
     val summary: String,

--- a/app/src/main/java/nl/jaysh/recipe/di/NetworkModule.kt
+++ b/app/src/main/java/nl/jaysh/recipe/di/NetworkModule.kt
@@ -7,8 +7,8 @@ import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import nl.jaysh.recipe.core.data.network.KtorClient
-import nl.jaysh.recipe.core.data.network.service.RecipeService
-import nl.jaysh.recipe.core.data.network.service.RecipeServiceImpl
+import nl.jaysh.recipe.core.data.network.service.RecipeRemoteDataSource
+import nl.jaysh.recipe.core.data.network.service.RecipeRemoteDataSourceImpl
 import javax.inject.Singleton
 
 @Module
@@ -24,7 +24,7 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun providesRecipeService(httpClient: HttpClient): RecipeService {
-        return RecipeServiceImpl(httpClient = httpClient)
+    fun providesRecipeService(httpClient: HttpClient): RecipeRemoteDataSource {
+        return RecipeRemoteDataSourceImpl(httpClient = httpClient)
     }
 }

--- a/app/src/main/java/nl/jaysh/recipe/feature/recipe/RecipeDetailViewModel.kt
+++ b/app/src/main/java/nl/jaysh/recipe/feature/recipe/RecipeDetailViewModel.kt
@@ -55,7 +55,7 @@ class RecipeDetailViewModel @Inject constructor(
         emit(newState)
 
         repository
-            .fetchRecipeDetail(recipeId)
+            .getDetails(recipeId)
             .collect { recipeDetail ->
                 recipeDetail?.let {
                     it.fold(

--- a/app/src/main/java/nl/jaysh/recipe/feature/recipe/RecipeOverviewScreen.kt
+++ b/app/src/main/java/nl/jaysh/recipe/feature/recipe/RecipeOverviewScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import nl.jaysh.recipe.R
-import nl.jaysh.recipe.core.domain.model.search.SearchRecipeResult
+import nl.jaysh.recipe.core.domain.model.search.SearchResult
 import nl.jaysh.recipe.core.designsystem.theme.RecipeTheme
 import nl.jaysh.recipe.core.designsystem.theme.blue
 import nl.jaysh.recipe.core.ui.composables.RecipeAsyncImage
@@ -125,7 +125,7 @@ private fun RecipeOverviewContent(
 @Composable
 private fun RecipeOverview(
     modifier: Modifier = Modifier,
-    searchResults: List<SearchRecipeResult>,
+    searchResults: List<SearchResult>,
     onSelectRecipe: (Long) -> Unit,
 ) = LazyVerticalGrid(
     columns = GridCells.Fixed(2),
@@ -142,7 +142,7 @@ private fun RecipeOverview(
 }
 
 @Composable
-private fun RecipeCard(recipe: SearchRecipeResult, onClick: (Long) -> Unit) = Card {
+private fun RecipeCard(recipe: SearchResult, onClick: (Long) -> Unit) = Card {
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/nl/jaysh/recipe/feature/recipe/RecipeOverviewViewModel.kt
+++ b/app/src/main/java/nl/jaysh/recipe/feature/recipe/RecipeOverviewViewModel.kt
@@ -1,6 +1,5 @@
 package nl.jaysh.recipe.feature.recipe
 
-import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,7 +17,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import nl.jaysh.recipe.core.domain.RecipeRepository
 import nl.jaysh.recipe.core.domain.model.failure.Failure
-import nl.jaysh.recipe.core.domain.model.search.SearchRecipeResult
+import nl.jaysh.recipe.core.domain.model.search.SearchResult
 import nl.jaysh.recipe.feature.recipe.FetchRecipeState.Error
 import nl.jaysh.recipe.feature.recipe.FetchRecipeState.Loading
 import nl.jaysh.recipe.feature.recipe.FetchRecipeState.Success
@@ -52,7 +51,7 @@ class RecipeOverviewViewModel @Inject constructor(
         emit(newState)
 
         repository
-            .searchRecipes(query)
+            .search(query)
             .collect { result ->
                 result.fold(
                     ifLeft = { failure ->
@@ -76,5 +75,5 @@ data class RecipeOverviewViewModelState(
 sealed interface FetchRecipeState {
     data object Loading : FetchRecipeState
     data class Error(val failure: Failure) : FetchRecipeState
-    data class Success(val recipes: List<SearchRecipeResult>) : FetchRecipeState
+    data class Success(val recipes: List<SearchResult>) : FetchRecipeState
 }

--- a/app/src/test/java/nl/jaysh/recipe/core/data/repository/RecipeRepositoryTest.kt
+++ b/app/src/test/java/nl/jaysh/recipe/core/data/repository/RecipeRepositoryTest.kt
@@ -44,7 +44,7 @@ class RecipeRepositoryTest {
 
     @Test
     fun `search successful`() = runTest {
-        val response = Either.Right(SearchRecipeObjects.searchResponseDTO)
+        val response = Either.Right(SearchRecipeObjects.testSearchResponseDTO)
         coEvery { service.search(query = any()) } returns response
 
         val result = repository.search(query = testQuery).first()
@@ -69,7 +69,7 @@ class RecipeRepositoryTest {
 
     @Test
     fun `getDetails in cache do not fetch recipeDetail from network`() = runTest {
-        coEvery { dao.getById(id = any()) } returns flowOf(RecipeDetailObjects.recipeDetailEntity)
+        coEvery { dao.getById(id = any()) } returns flowOf(RecipeDetailObjects.testRecipeDetailEntity)
         coEvery { dao.save(recipe = any()) } returns Unit
         val response = Either.Right(testRecipeDetailDTO)
         coEvery { service.getDetails(recipeId = any()) } returns response
@@ -106,8 +106,8 @@ class RecipeRepositoryTest {
     @Test
     fun `get favourite recipe should get from db successful`() = runTest {
         val entities = listOf(
-            RecipeDetailObjects.recipeDetailEntity.copy(id = 1L),
-            RecipeDetailObjects.recipeDetailEntity.copy(id = 2L),
+            RecipeDetailObjects.testRecipeDetailEntity.copy(id = 1L),
+            RecipeDetailObjects.testRecipeDetailEntity.copy(id = 2L),
         )
         coEvery { dao.getFavourites() } returns flowOf(entities)
 

--- a/app/src/test/java/nl/jaysh/recipe/core/data/repository/RecipeRepositoryTest.kt
+++ b/app/src/test/java/nl/jaysh/recipe/core/data/repository/RecipeRepositoryTest.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import nl.jaysh.recipe.core.data.local.room.dao.RecipeDetailDao
-import nl.jaysh.recipe.core.data.network.service.RecipeService
+import nl.jaysh.recipe.core.data.network.service.RecipeRemoteDataSource
 import nl.jaysh.recipe.core.domain.RecipeRepository
 import nl.jaysh.recipe.core.domain.model.failure.StorageFailure
 import nl.jaysh.recipe.helper.objects.RecipeDetailObjects
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
 class RecipeRepositoryTest {
 
     private lateinit var dao: RecipeDetailDao
-    private lateinit var service: RecipeService
+    private lateinit var service: RecipeRemoteDataSource
     private lateinit var repository: RecipeRepository
 
     private val testQuery = "Lasagna"
@@ -37,65 +37,65 @@ class RecipeRepositoryTest {
         service = mockk()
         repository = RecipeRepositoryImpl(
             dao = dao,
-            recipeService = service,
+            recipeRemoteDataSource = service,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }
 
     @Test
-    fun `searchRecipes successful`() = runTest {
+    fun `search successful`() = runTest {
         val response = Either.Right(SearchRecipeObjects.searchResponseDTO)
-        coEvery { service.searchRecipes(query = any()) } returns response
+        coEvery { service.search(query = any()) } returns response
 
-        val result = repository.searchRecipes(query = testQuery).first()
+        val result = repository.search(query = testQuery).first()
         assertThat(result.getOrNull()?.size).isEqualTo(2)
 
-        coVerify(exactly = 1) { service.searchRecipes(query = testQuery) }
+        coVerify(exactly = 1) { service.search(query = testQuery) }
     }
 
     @Test
-    fun `recipe detail NOT cached should fetch from network and save record in DB`() = runTest {
+    fun `getDetails NOT cached should fetch from network and save record in DB`() = runTest {
         coEvery { dao.getById(id = any()) } returns flowOf(null)
         coEvery { dao.save(recipe = any()) } returns Unit
         val response = Either.Right(testRecipeDetailDTO)
-        coEvery { service.fetchRecipeDetail(recipeId = any()) } returns response
+        coEvery { service.getDetails(recipeId = any()) } returns response
 
-        repository.fetchRecipeDetail(recipeId = testRecipeId).first()
+        repository.getDetails(recipeId = testRecipeId).first()
 
         coVerify(exactly = 1) { dao.getById(id = testRecipeId) }
-        coVerify(exactly = 1) { service.fetchRecipeDetail(recipeId = any()) }
+        coVerify(exactly = 1) { service.getDetails(recipeId = any()) }
         coVerify(exactly = 1) { dao.save(recipe = any()) }
     }
 
     @Test
-    fun `recipe detail in cache do not fetch recipeDetail from network`() = runTest {
+    fun `getDetails in cache do not fetch recipeDetail from network`() = runTest {
         coEvery { dao.getById(id = any()) } returns flowOf(RecipeDetailObjects.recipeDetailEntity)
         coEvery { dao.save(recipe = any()) } returns Unit
         val response = Either.Right(testRecipeDetailDTO)
-        coEvery { service.fetchRecipeDetail(recipeId = any()) } returns response
+        coEvery { service.getDetails(recipeId = any()) } returns response
 
-        repository.fetchRecipeDetail(recipeId = testRecipeId).first()
+        repository.getDetails(recipeId = testRecipeId).first()
 
         coVerify(exactly = 1) { dao.getById(id = testRecipeId) }
-        coVerify(exactly = 0) { service.fetchRecipeDetail(recipeId = any()) }
+        coVerify(exactly = 0) { service.getDetails(recipeId = any()) }
         coVerify(exactly = 0) { dao.save(recipe = any()) }
     }
 
     @Test
-    fun `recipe detail NOT cached can throw error saving to db`() = runTest {
+    fun `getDetails NOT cached can throw error saving to db`() = runTest {
         coEvery { dao.getById(id = any()) } returns flowOf(null)
         val successResponse = Either.Right(testRecipeDetailDTO)
-        coEvery { service.fetchRecipeDetail(recipeId = any()) } returns successResponse
+        coEvery { service.getDetails(recipeId = any()) } returns successResponse
         coEvery { dao.save(recipe = any()) } throws RuntimeException()
 
-        val result = repository.fetchRecipeDetail(recipeId = testRecipeId).first()
+        val result = repository.getDetails(recipeId = testRecipeId).first()
         assertThat(result?.leftOrNull()).isEqualTo(StorageFailure.IO)
 
         coVerify(exactly = 1) { dao.save(any()) }
     }
 
     @Test
-    fun `set recipe as favourite should update in db`() = runTest {
+    fun `set as favourite should update in db`() = runTest {
         coEvery { dao.updateFavouriteStatus(recipeId = any(), isFavourite = true) } returns Unit
 
         repository.setFavouriteRecipe(recipeId = testRecipeId, isFavourite = true)

--- a/app/src/test/java/nl/jaysh/recipe/feature/recipe/RecipeDetailViewModelTest.kt
+++ b/app/src/test/java/nl/jaysh/recipe/feature/recipe/RecipeDetailViewModelTest.kt
@@ -76,7 +76,7 @@ class RecipeDetailViewModelTest {
 
     @Test
     fun `savedStateHandle with value should set recipeId`() = runTest {
-        every { repository.fetchRecipeDetail(recipeId = any()) } returns emptyFlow()
+        every { repository.getDetails(recipeId = any()) } returns emptyFlow()
 
         viewModel.state.test {
             val initialEmission = awaitItem()
@@ -90,7 +90,7 @@ class RecipeDetailViewModelTest {
     @Test
     fun `should fetch recipe detail initially`() = runTest {
         val fakeNetworkDelay = 200L
-        every { repository.fetchRecipeDetail(recipeId = any()) } returns flow {
+        every { repository.getDetails(recipeId = any()) } returns flow {
             emit(null)
             delay(fakeNetworkDelay)
             emit(Either.Right(RecipeDetailObjects.recipeDetail))
@@ -107,13 +107,13 @@ class RecipeDetailViewModelTest {
             expectNoEvents()
         }
 
-        verify(exactly = 1) { repository.fetchRecipeDetail(recipeId = recipeId) }
+        verify(exactly = 1) { repository.getDetails(recipeId = recipeId) }
     }
 
     @Test
     fun `fetch recipe detail failure should error`() = runTest {
         val fakeNetworkDelay = 200L
-        every { repository.fetchRecipeDetail(recipeId = any()) } returns flow {
+        every { repository.getDetails(recipeId = any()) } returns flow {
             emit(null)
             delay(fakeNetworkDelay)
             emit(Either.Left(NetworkFailure.UNAUTHORIZED))
@@ -131,6 +131,6 @@ class RecipeDetailViewModelTest {
             expectNoEvents()
         }
 
-        verify(exactly = 1) { repository.fetchRecipeDetail(recipeId = recipeId) }
+        verify(exactly = 1) { repository.getDetails(recipeId = recipeId) }
     }
 }

--- a/app/src/test/java/nl/jaysh/recipe/feature/recipe/RecipeDetailViewModelTest.kt
+++ b/app/src/test/java/nl/jaysh/recipe/feature/recipe/RecipeDetailViewModelTest.kt
@@ -93,7 +93,7 @@ class RecipeDetailViewModelTest {
         every { repository.getDetails(recipeId = any()) } returns flow {
             emit(null)
             delay(fakeNetworkDelay)
-            emit(Either.Right(RecipeDetailObjects.recipeDetail))
+            emit(Either.Right(RecipeDetailObjects.testRecipeDetail))
         }
 
         viewModel.state.test {

--- a/app/src/test/java/nl/jaysh/recipe/feature/recipe/RecipeOverviewViewModelTest.kt
+++ b/app/src/test/java/nl/jaysh/recipe/feature/recipe/RecipeOverviewViewModelTest.kt
@@ -66,7 +66,7 @@ class RecipeOverviewViewModelTest {
     fun `unsuccessful fetch recipes initially`() = runTest {
         val fakeNetworkDelay = 200L
         val failingRepository = mockk<RecipeRepository>()
-        every { failingRepository.searchRecipes(query = any()) } returns flow {
+        every { failingRepository.search(query = any()) } returns flow {
             delay(fakeNetworkDelay)
             emit(Either.Left(NetworkFailure.UNAUTHORIZED))
         }
@@ -85,7 +85,7 @@ class RecipeOverviewViewModelTest {
             expectNoEvents()
         }
 
-        verify(exactly = 1) { failingRepository.searchRecipes(query = any()) }
+        verify(exactly = 1) { failingRepository.search(query = any()) }
     }
 
     @Test

--- a/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRemoteDataSource.kt
+++ b/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRemoteDataSource.kt
@@ -3,21 +3,21 @@ package nl.jaysh.recipe.helper
 import arrow.core.Either
 import nl.jaysh.recipe.core.data.network.model.detail.RecipeDetailDTO
 import nl.jaysh.recipe.core.data.network.model.search.SearchResponseDTO
-import nl.jaysh.recipe.core.data.network.service.RecipeService
+import nl.jaysh.recipe.core.data.network.service.RecipeRemoteDataSource
 import nl.jaysh.recipe.core.domain.model.failure.Failure
 import nl.jaysh.recipe.helper.objects.RecipeDetailObjects
 import nl.jaysh.recipe.helper.objects.SearchRecipeObjects
 
-class FakeRecipeService : RecipeService {
+class FakeRecipeRemoteDataSource : RecipeRemoteDataSource {
 
     private var searchResponse = SearchRecipeObjects.searchResponseDTO
     private var informationResponse = RecipeDetailObjects.testRecipeDetailDTO
 
-    override suspend fun searchRecipes(query: String): Either<Failure, SearchResponseDTO> {
+    override suspend fun search(query: String): Either<Failure, SearchResponseDTO> {
         return Either.Right(searchResponse)
     }
 
-    override suspend fun fetchRecipeDetail(recipeId: Long): Either<Failure, RecipeDetailDTO> {
+    override suspend fun getDetails(recipeId: Long): Either<Failure, RecipeDetailDTO> {
         return Either.Right(informationResponse)
     }
 }

--- a/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRemoteDataSource.kt
+++ b/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRemoteDataSource.kt
@@ -10,7 +10,7 @@ import nl.jaysh.recipe.helper.objects.SearchRecipeObjects
 
 class FakeRecipeRemoteDataSource : RecipeRemoteDataSource {
 
-    private var searchResponse = SearchRecipeObjects.searchResponseDTO
+    private var searchResponse = SearchRecipeObjects.testSearchResponseDTO
     private var informationResponse = RecipeDetailObjects.testRecipeDetailDTO
 
     override suspend fun search(query: String): Either<Failure, SearchResponseDTO> {

--- a/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRepository.kt
+++ b/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRepository.kt
@@ -14,7 +14,7 @@ import nl.jaysh.recipe.helper.objects.RecipeDetailObjects
 class FakeRecipeRepository : RecipeRepository {
 
     private var recipes: List<SearchResult> = mutableListOf()
-    private var recipeDetail = RecipeDetailObjects.recipeDetail
+    private var recipeDetail = RecipeDetailObjects.testRecipeDetail
 
     override fun search(query: String): Flow<Either<Failure, List<SearchResult>>> {
         return flow {

--- a/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRepository.kt
+++ b/app/src/test/java/nl/jaysh/recipe/helper/FakeRecipeRepository.kt
@@ -8,15 +8,15 @@ import kotlinx.coroutines.flow.flow
 import nl.jaysh.recipe.core.domain.RecipeRepository
 import nl.jaysh.recipe.core.domain.model.detail.RecipeDetail
 import nl.jaysh.recipe.core.domain.model.failure.Failure
-import nl.jaysh.recipe.core.domain.model.search.SearchRecipeResult
+import nl.jaysh.recipe.core.domain.model.search.SearchResult
 import nl.jaysh.recipe.helper.objects.RecipeDetailObjects
 
 class FakeRecipeRepository : RecipeRepository {
 
-    private var recipes: List<SearchRecipeResult> = mutableListOf()
+    private var recipes: List<SearchResult> = mutableListOf()
     private var recipeDetail = RecipeDetailObjects.recipeDetail
 
-    override fun searchRecipes(query: String): Flow<Either<Failure, List<SearchRecipeResult>>> {
+    override fun search(query: String): Flow<Either<Failure, List<SearchResult>>> {
         return flow {
             // Fake fetching data delay
             delay(FAKE_DELAY)
@@ -25,7 +25,7 @@ class FakeRecipeRepository : RecipeRepository {
         }
     }
 
-    override fun fetchRecipeDetail(recipeId: Long): Flow<Either<Failure, RecipeDetail>?> = flow {
+    override fun getDetails(recipeId: Long): Flow<Either<Failure, RecipeDetail>?> = flow {
         // Fake fetching data delay
         delay(FAKE_DELAY)
 

--- a/app/src/test/java/nl/jaysh/recipe/helper/objects/RecipeDetailObjects.kt
+++ b/app/src/test/java/nl/jaysh/recipe/helper/objects/RecipeDetailObjects.kt
@@ -23,7 +23,7 @@ object RecipeDetailObjects {
         image = "water.png"
     )
 
-    val recipeDetail = RecipeDetail(
+    val testRecipeDetail = RecipeDetail(
         id = 640864L,
         title = "Crock Pot Lasagna",
         readyInMinutes = 45,
@@ -58,7 +58,7 @@ object RecipeDetailObjects {
         extendedIngredients = emptyList(),
     )
 
-    val recipeDetailEntity = RecipeDetailEntity(
+    val testRecipeDetailEntity = RecipeDetailEntity(
         id = 640864L,
         title = "Crock Pot Lasagna",
         readyInMinutes = 45,

--- a/app/src/test/java/nl/jaysh/recipe/helper/objects/SearchRecipeObjects.kt
+++ b/app/src/test/java/nl/jaysh/recipe/helper/objects/SearchRecipeObjects.kt
@@ -4,7 +4,7 @@ import nl.jaysh.recipe.core.data.network.model.search.SearchResponseDTO
 import nl.jaysh.recipe.core.data.network.model.search.SearchResultDTO
 
 object SearchRecipeObjects {
-    val searchResponseDTO = SearchResponseDTO(
+    val testSearchResponseDTO = SearchResponseDTO(
         results = listOf(
             SearchResultDTO(
                 id = 640864L,


### PR DESCRIPTION
# clean/improve-naming

Pull request includes:
* Renamed `RecipeService` to `RecipeRemoteDataSource`
* Renamed model `SearchRecipeResult` to `SearchResult`